### PR TITLE
Lint: Strip whitespace from values #1485

### DIFF
--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -99,7 +99,7 @@ class Result:
                                         end_column)
 
         return cls(origin=origin,
-                   message=message,
+                   message=message.strip(),
                    affected_code=(range,),
                    severity=severity,
                    debug_msg=debug_msg,


### PR DESCRIPTION
Lint: Strip whitespace from values #1485
This is to strip the leading and trailing spaces in the 'message' parameter from the method from_values() in Result.py
from_values(cls,
                    origin,
                    message: str,
                    file: str,
                    line: (int, None)=None,
                    column: (int, None)=None,
                    end_line: (int, None)=None,
                    end_column: (int, None)=None,
                    severity: int=RESULT_SEVERITY.NORMAL,
                    debug_msg="",
                    diffs: (dict, None)=None):
